### PR TITLE
ui: adds visibility toggle for metrics

### DIFF
--- a/src/MetricHandler.js
+++ b/src/MetricHandler.js
@@ -147,6 +147,8 @@ export class MetricHandler {
     let allMinMax = [undefined, undefined]
     const timeFrame = this.renderer.graticule.curTimeRange
     for (const curMetric of this.store.getters['metrics/getAll']()) {
+      if (!curMetric.draw) continue
+
       const curCache = this.renderer.graticule.data.getMetricCache(curMetric.key)
       if (curCache) {
         let curMinMax

--- a/src/MetricQWebView.js
+++ b/src/MetricQWebView.js
@@ -144,6 +144,12 @@ class MetricQWebView {
     this.setPlotRanges(false, true)
   }
 
+  toggleDraw (metricBase) {
+    this.store.dispatch('metrics/toggleDraw', { metricKey: metricBase })
+    if (this.graticule) this.graticule.draw(false)
+    this.setPlotRanges(false, true)
+  }
+
   async changeMetricName (oldMetric, newName) {
     if (await this.addMetric(newName, undefined, oldMetric)) {
       this.deleteMetric(oldMetric.name)

--- a/src/data-handling.js
+++ b/src/data-handling.js
@@ -1,6 +1,7 @@
 import { crc32 } from '../lib/pseudo-crc32.js'
 import { hslToRgb } from '../lib/color-conversion.js'
 import moment from 'moment'
+import store from './store/'
 
 export class DataCache {
   constructor (paramMetricQHistoryReference) {
@@ -108,6 +109,8 @@ export class DataCache {
     let min
     let max
     for (let i = 0; i < this.metrics.length; ++i) {
+      if (!store.getters['metrics/getMetricDrawState'](this.metrics[i].name).draw) continue
+
       if (doGetAllTime && this.metrics[i].allTime) {
         if (undefined === min || min > this.metrics[i].allTime.min) {
           min = this.metrics[i].allTime.min

--- a/src/graticule.js
+++ b/src/graticule.js
@@ -22,7 +22,7 @@ export class Graticule {
     }
     this.data = new DataCache(paramMetricQHistoryReference)
     // TODO: take these non-changing parameters
-    //      as parameters to initialisation
+    //      as parameters to initialization
     this.MAX_ZOOM_TIME = 20 * 365 * 24 * 3600 * 1000
     this.MIN_ZOOM_TIME = 10
     this.DEFAULT_FONT = 'sans-serif'
@@ -655,6 +655,8 @@ export class Graticule {
 
   drawBands (timeRange, valueRange, timePerPixel, valuesPerPixel, ctx, graticuleDimensions) {
     for (let i = 0; i < this.data.metrics.length; ++i) {
+      if (!store.getters['metrics/getMetricDrawState'](this.data.metrics[i].name).draw) continue
+
       if (store.getters['metrics/getMetricDrawState'](this.data.metrics[i].name).drawMin && store.getters['metrics/getMetricDrawState'](this.data.metrics[i].name).drawMax) {
         const curBand = this.data.metrics[i].band
         if (curBand) {
@@ -714,6 +716,8 @@ export class Graticule {
 
   drawSeries (timeRange, valueRange, timePerPixel, valuesPerPixel, ctx, graticuleDimensions) {
     for (let i = 0; i < this.data.metrics.length; ++i) {
+      if (!store.getters['metrics/getMetricDrawState'](this.data.metrics[i].name).draw) continue
+
       if (this.data.metrics[i].series.raw === undefined) {
         const metricDrawState = store.getters['metrics/getMetricDrawState'](this.data.metrics[i].name)
         this.data.metrics[i].series.avg.styleOptions.skip = !metricDrawState.drawAvg

--- a/src/store/metrics.js
+++ b/src/store/metrics.js
@@ -12,6 +12,7 @@ export default {
     getMetricDrawState: (state) => (metricName) => {
       const metric = state.metrics[metricName]
       return {
+        draw: metric.draw,
         drawMin: metric.drawMin,
         drawAvg: metric.drawAvg,
         drawMax: metric.drawMax
@@ -37,7 +38,7 @@ export default {
 
     privateSet (state, {
       metricKey,
-      metric: { name, description, unit, color, marker, errorprone, drawMin, drawMax, drawAvg, pointsAgg, pointsRaw }
+      metric: { name, description, unit, color, marker, errorprone, drawMin, drawMax, drawAvg, pointsAgg, pointsRaw, draw }
     }) {
       if (name !== undefined && metricKey !== name) {
         throw new Error('metricKey and metric.name must be equal!')
@@ -52,6 +53,7 @@ export default {
           color: color || MetricHelper.metricBaseToRgb(metricKey),
           errorprone: errorprone === undefined ? false : errorprone,
           popup: false,
+          draw: draw === undefined ? true : draw,
           drawMin: drawMin === undefined ? store.state.globalMinMax : drawMin,
           drawAvg: drawAvg === undefined ? true : drawAvg,
           drawMax: drawMax === undefined ? store.state.globalMinMax : drawMax,
@@ -80,6 +82,9 @@ export default {
         }
         if (errorprone !== undefined) {
           Vue.set(state.metrics[metricKey], 'errorprone', errorprone)
+        }
+        if (draw !== undefined) {
+          Vue.set(state.metrics[metricKey], 'draw', draw)
         }
         if (drawMin !== undefined) {
           Vue.set(state.metrics[metricKey], 'drawMin', drawMin)
@@ -232,6 +237,9 @@ export default {
     updateDrawState ({ dispatch, commit }, { metricKey, drawState: { drawMin, drawAvg, drawMax } }) {
       commit('privateSet', { metricKey, metric: { drawMin, drawAvg, drawMax } })
       dispatch('checkGlobalDrawState')
+    },
+    toggleDraw ({ state, commit }, { metricKey }) {
+      commit('privateSet', { metricKey, metric: { draw: !state.metrics[metricKey].draw } })
     },
     updateDataPoints ({ state, commit }, { metricKey, pointsAgg, pointsRaw }) {
       commit('privateSet', { metricKey, metric: { pointsAgg: pointsAgg, pointsRaw: pointsRaw } })

--- a/src/ui/metric-legend.vue
+++ b/src/ui/metric-legend.vue
@@ -1,13 +1,14 @@
 <template>
   <li
-    :class="'legend_item legend_item_' + position"
+    :class="[{ 'no_drawing' : !draw } , 'legend_item', 'legend_item_' + position]"
   >
     <table>
       <tr>
         <td>
           <div
-            :class="metric.popupKey"
-            :style="{ backgroundColor: metric.color }"
+            :class="[metric.popupKey, 'clickable']"
+            :style="{ backgroundColor: color }"
+            @click="metricPopup"
           />
         </td>
         <td>
@@ -29,6 +30,17 @@
         </td>
         <td>
           <span class="clickables">
+            <b-icon-eye-fill
+              v-if="draw"
+              class="clickable"
+              @click="toggleDraw"
+            />
+            <b-icon-eye-slash
+              v-else
+              class="clickable"
+              @click="toggleDraw"
+            />
+            &nbsp;
             <b-icon-pencil
               class="clickable"
               variant="primary"
@@ -74,6 +86,14 @@ export default {
       maxwidth: 0
     }
   },
+  computed: {
+    draw () {
+      return this.$props.metric.draw
+    },
+    color () {
+      return this.$props.metric.draw ? this.$props.metric.color : 'grey'
+    }
+  },
   updated () {
     this.maxwidth = this.$refs.metricName.clientWidth + this.$refs.metricDesc.clientWidth + 100
     this.onResize()
@@ -98,6 +118,9 @@ export default {
       const style = getComputedStyle(document.body)
       const docMaxWidth = style.getPropertyValue('--legend_right_max_width').slice(0, -2) * document.body.clientWidth / 100
       this.multiline = this.maxwidth > docMaxWidth
+    },
+    toggleDraw () {
+      window.MetricQWebView.instances[0].toggleDraw(this.$props.metric.name)
     }
   }
 }
@@ -109,6 +132,11 @@ export default {
   margin-bottom: -2px;
   display: inline-block;
   text-align: left;
+}
+
+.no_drawing {
+  background-color: lightgrey;
+  color: grey;
 }
 
 .metricImg {


### PR DESCRIPTION
Adds an (slashed) eye to the metric legend. Clicking on that toggles the visiblity for each metric.

![grafik](https://user-images.githubusercontent.com/130405/180441271-eda10bee-ae21-4c07-8efe-39863a4a6563.png)
