### PR TITLE
Fix: X-Axis-Labeling, when incrementing year, be aware of Leap Years

### DIFF
--- a/src/graticule.js
+++ b/src/graticule.js
@@ -203,7 +203,9 @@ export class Graticule {
     // make sure that we don't start our steps before our minimum time
     if (i !== 1) {
       while (stepStart.getTime() < this.curTimeRange[0]) {
-        stepStart = new Date(stepStart.getTime() + stepSize)
+        let timeIncrement = stepSize
+        if (this.isLeapYear(stepStart.getFullYear())) timeIncrement += 86400 * 1000
+        stepStart = new Date(stepStart.getTime() + timeIncrement)
       }
     }
     // now finally, we got everything figured out
@@ -244,6 +246,7 @@ export class Graticule {
       switch (i) {
         case 0: // years
           stepItem.label.push('' + curDate.getFullYear())
+          if (this.isLeapYear(curDate.getFullYear())) j += 86400 * 1000
           break
         case 1: // months
           if (curDate.getMonth() === 0 || !previousCurDate || previousCurDate.getFullYear() !== curDate.getFullYear()) {
@@ -294,6 +297,17 @@ export class Graticule {
       previousCurDate = curDate
     }
     return outArr
+  }
+
+  isLeapYear (paramYear) {
+    paramYear = parseInt(paramYear)
+
+    if ((paramYear % 400) === 0 ||
+       ((paramYear % 4) === 0 &&
+        (paramYear % 100) !== 0)) {
+      return true
+    }
+    return false
   }
 
   figureOutLogarithmicSteps (rangeStart, rangeEnd, maxStepsAllowed) {


### PR DESCRIPTION
Implemented check for `isLeapYear()` and used it for increasing the axis' Year, such that in case of Leap Years it doesn't end up adding 365 days to first of January, and then it happens to be the 31st of December of the **same year**.

You can test the updated axis-labeling algorithm in the JavaScript-**Console** like this:
`var grat = window.MetricQWebView.instances[0].graticule; var maxStepsAllowed=grat.graticuleDimensions[2]/110; grat.figureOutTimeSteps(maxStepsAllowed).forEach((val)=>{console.log(new Date(val.timestamp));})`

I linted it and looked at it in browser without it causing errors ('though without data access due to CORS). I think the source code is fine.

@bmario: Please be so kind to review/merge this.