### PR TITLE
Fine tuned the earlier patch for issue #196; now we fix#197

### DIFF
--- a/src/graticule.js
+++ b/src/graticule.js
@@ -153,7 +153,7 @@ export class Graticule {
       case 1:
         fields[0] = startTime.getFullYear()
         // getMonth() will return a number 0 - 11, which I find rather
-        //   intuitive. We have to increment it by one each time we query it.
+        //   unintuitive. We have to increment it by one each time we query it.
         fields[1] = (startTime.getMonth() + 1) - ((startTime.getMonth() + 1) % curRangeMultiplier)
         if (fields[1] < 1) {
           fields[1] = 1
@@ -206,7 +206,7 @@ export class Graticule {
     }
     stepStart = new Date(fields[0] + '-' + (fields[1] < 10 ? '0' : '') + fields[1] + '-' + (fields[2] < 10 ? '0' : '') + fields[2] + ' ' + (fields[3] < 10 ? '0' : '') + fields[3] + ':' + (fields[4] < 10 ? '0' : '') + fields[4] + ':' + (fields[5] < 10 ? '0' : '') + fields[5] + '.' + (fields[6] < 100 ? '00' : (fields[6] < 10 ? '0' : '')) + fields[6])
     // make sure that we don't start our steps before our minimum time
-    if (i !== 1) {
+    if (i === 0) {
       while (stepStart.getTime() < this.curTimeRange[0]) {
         let timeIncrement = stepSize
         if (this.isLeapYear(stepStart.getFullYear())) timeIncrement += 86400 * 1000


### PR DESCRIPTION
Fixing #197 (the incorrect x-axis labeling)

Addendum to [solution **B**](https://github.com/metricq/metricq-webview/issues/197#issuecomment-1904180850): Despite my earlier assumption, at closer inspection, adding an additional day is ALWAYS necessary - however only for zoom/stepSize of one year (i.e. `i === 0`).


### Regarding Testing it:

Testing was only partially successfull, due to security measures (e.g. CORS), however, both error cases provided, appeared promising to me, resulting in the two offending cases to be resolved:
- with timestamp from the older Issue#195, [here](https://metricq.zih.tu-dresden.de/webview/#.1487443092579.2*1820283463271.2*elab.ariel.power)
- with a timestamp of yesterday, which displayed the latest Issue#197, [link here](https://metricq.zih.tu-dresden.de/webview/#.1705781330461*1705921104061*elab.ariel.power)

Please verify.

**Note**: A reviewer might particularly investigate zoom levels of Year, Month and Day, both for an overview of years, but also for days before February 29th of a leap year and right after it.